### PR TITLE
Fix major bug in _distribute_weights() to support iteration-level selection

### DIFF
--- a/lib/python/examples/fwdllm/expts/run_tc_expts/mpi_host_file
+++ b/lib/python/examples/fwdllm/expts/run_tc_expts/mpi_host_file
@@ -1,1 +1,1 @@
-jayne.cc.gatech.edu
+wash.cc.gatech.edu

--- a/lib/python/examples/fwdllm/expts/run_tc_expts/run_text_classification.sh
+++ b/lib/python/examples/fwdllm/expts/run_tc_expts/run_text_classification.sh
@@ -331,7 +331,7 @@ else
       fi
   done
 
-  echo "Log files created: \n [Aggregator]: $AGG_LOG_FILE \n [Trainer]: $TRAINER_LOG_FILE"
+  echo -e "Log files created: \n [Aggregator]: $AGG_LOG_FILE \n [Trainer]: $TRAINER_LOG_FILE"
 
   # Start background periodic check (every 30 seconds)
   # The watchdog will automatically exit if the parent process ($PARENT_PID) dies

--- a/lib/python/flame/mode/horizontal/syncfl/fwdllm_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/fwdllm_aggregator.py
@@ -212,6 +212,8 @@ class TopAggregator(AsyncTopAgg):
         """Initialize internal state for role."""
         super().internal_init()
 
+        self._trainer_last_model_version = {}
+
         self._agg_goal_cnt = 0
         self._agg_goal_weights = None
         self._agg_goal = self.config.hyperparameters.aggregation_goal or 1
@@ -723,6 +725,7 @@ class TopAggregator(AsyncTopAgg):
             logger.info(f"grad_pool already has: {len(self.grad_pool)}")
 
         version = msg.get(MessageType.MODEL_VERSION, "unknown")
+        self._trainer_last_model_version[end] = version
         logger.info(
             f"Received grads from {end}. It was trained on model version {version}, with {count} samples"
         )
@@ -1065,13 +1068,13 @@ class TopAggregator(AsyncTopAgg):
         return picked_trainer_is_available
 
     @timer_decorator
-    def _prepare_distribution_payload(self, task_to_perform: str):
+    def _prepare_distribution_payload(self, task_to_perform: str, force_weights: bool = False):
         if self.var:
             logger.info(
                 f"self.var = {self.var}, self.var_threshold = {self.var_threshold}"
             )
 
-        if not self.var_good_enough:
+        if not self.var_good_enough and not force_weights:
             logger.info(
                 "Sending variance = bad to trainers since variance is greater than threshold"
             )
@@ -1184,10 +1187,27 @@ class TopAggregator(AsyncTopAgg):
             )
             return
 
-        payload = self._prepare_distribution_payload(task_to_perform)
+        payload_var_bad = None
+        payload_weights = self._prepare_distribution_payload(task_to_perform, force_weights=True)
+        if not self.var_good_enough:
+            payload_var_bad = self._prepare_distribution_payload(task_to_perform, force_weights=False)
+        
+
         self._update_state_after_payload_prepared()
 
         for end in ends:
+            trainer_version = self._trainer_last_model_version.get(end, -1)
+            is_stale = (trainer_version != self._model_version)
+
+            if self.var_good_enough:
+                payload = payload_weights
+            else:
+                if is_stale:
+                    payload = payload_weights
+                    logger.info(f"Trainer {end} hasn't received weights for model_version {self._model_version} (has {trainer_version}). Sending WEIGHTS payload instead of VAR=bad.")
+                else:
+                    payload = payload_var_bad
+
             logger.debug(
                 f"Setting channel property {PROP_ROUND_START_TIME} for "
                 f"end {end}. For round {self._round} at time: {datetime.now()}"
@@ -1306,7 +1326,11 @@ class TopAggregator(AsyncTopAgg):
                 "Sending variance = bad to trainers since variance is greater than threshold"
             )
 
-        payload = self._prepare_distribution_payload(task_to_perform)
+        payload_var_bad = None
+        payload_weights = self._prepare_distribution_payload(task_to_perform, force_weights=True)
+        if not self.var_good_enough:
+            payload_var_bad = self._prepare_distribution_payload(task_to_perform, force_weights=False)
+        
         self._update_state_after_payload_prepared()
 
         if self.var_good_enough:
@@ -1315,6 +1339,19 @@ class TopAggregator(AsyncTopAgg):
             )
 
         for end in ends:
+            trainer_version = self._trainer_last_model_version.get(end, -1)
+            is_stale = (trainer_version != self._model_version)
+
+            if self.var_good_enough:
+                payload = payload_weights
+            else:
+                if is_stale:
+                    payload = payload_weights
+                    logger.debug("Trainer %s hasn't received weights for model_version %s (has %s). Sending WEIGHTS payload instead of VAR=bad.", end, self._model_version, trainer_version)
+                else:
+                    payload = payload_var_bad
+                    logger.debug("Trainer %s will be sent a VAR=bad payload.", end)
+
             logger.debug(
                 f"Setting channel property {PROP_ROUND_START_TIME} for "
                 f"end {end}. For round {self._round} at time: {datetime.now()}"

--- a/lib/python/flame/mode/horizontal/syncfl/fwdllm_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/fwdllm_aggregator.py
@@ -1190,10 +1190,10 @@ class TopAggregator(AsyncTopAgg):
             )
             return
 
-        payload_var_bad = None
-        payload_weights = self._prepare_distribution_payload(task_to_perform, force_weights=True)
+        payload_without_weights = None
+        payload_with_weights = self._prepare_distribution_payload(task_to_perform, force_weights=True)
         if not self.var_good_enough:
-            payload_var_bad = self._prepare_distribution_payload(task_to_perform, force_weights=False)
+            payload_without_weights = self._prepare_distribution_payload(task_to_perform, force_weights=False)
         
 
         self._update_state_after_payload_prepared()
@@ -1203,13 +1203,13 @@ class TopAggregator(AsyncTopAgg):
             is_stale = (trainer_version != self._model_version)
 
             if self.var_good_enough:
-                payload = payload_weights
+                payload = payload_with_weights
             else:
                 if is_stale:
-                    payload = payload_weights
+                    payload = payload_with_weights
                     logger.info(f"Trainer {end} hasn't received weights for model_version {self._model_version} (has {trainer_version}). Sending WEIGHTS payload instead of VAR=bad.")
                 else:
-                    payload = payload_var_bad
+                    payload = payload_without_weights
 
             logger.debug(
                 f"Setting channel property {PROP_ROUND_START_TIME} for "

--- a/lib/python/flame/mode/horizontal/syncfl/fwdllm_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/fwdllm_aggregator.py
@@ -240,6 +240,7 @@ class TopAggregator(AsyncTopAgg):
         self._is_model_updated = False
         self._model_version = 0
         self.grad_pool = []
+        self.cached_shared_grad_pool_trainable = None
         self.var = None
         self.ends_not_selected_yet = False
         self.iteration_per_data_id = 0
@@ -1100,20 +1101,22 @@ class TopAggregator(AsyncTopAgg):
             trainable_params, DeviceType.CPU
         )  # Need to move to CPU for sending over MQTT
 
-        shared_grad_pool = self.aggregate_grad_pool(self.grad_pool)
-        shared_grad_pool_trainable = []
-        if shared_grad_pool is None:
-            shared_grad_pool_trainable = None
-        else:
-            idx = 0
-            for param in self.model.parameters():
-                if param.requires_grad:
-                    shared_grad_pool_trainable.append(shared_grad_pool[idx].clone())
-                idx += 1
+        if self._is_model_updated:
+            shared_grad_pool = self.aggregate_grad_pool(self.grad_pool)
+            shared_grad_pool_trainable = []
+            if shared_grad_pool is None:
+                shared_grad_pool_trainable = None
+            else:
+                idx = 0
+                for param in self.model.parameters():
+                    if param.requires_grad:
+                        shared_grad_pool_trainable.append(shared_grad_pool[idx].clone())
+                    idx += 1
+            self.cached_shared_grad_pool_trainable = shared_grad_pool_trainable
 
         payload = {
             MessageType.WEIGHTS: shared_weights,
-            MessageType.GRAD_POOL: shared_grad_pool_trainable,
+            MessageType.GRAD_POOL: self.cached_shared_grad_pool_trainable,
             MessageType.ROUND: self._round,
             MessageType.MODEL_VERSION: self._model_version,
             MessageType.TASK_TO_PERFORM: task_to_perform,

--- a/lib/python/flame/mode/horizontal/syncfl/fwdllm_trainer.py
+++ b/lib/python/flame/mode/horizontal/syncfl/fwdllm_trainer.py
@@ -210,16 +210,10 @@ class Trainer(Role, metaclass=ABCMeta):
         if MessageType.ROUND in msg:
             self._round = msg[MessageType.ROUND]
 
-        if MessageType.MODEL_VERSION in msg:
-            self._model_version = msg[MessageType.MODEL_VERSION]
-
         logger.info(
             f"Checking DataID: {self.data_id}| MessageType.DATA_ID in msg: {msg[MessageType.DATA_ID]}| IterationPerDataID: {self.iteration_per_data_id}| MessageType.ITERATION_PER_DATA_ID in msg: {msg[MessageType.ITERATION_PER_DATA_ID]}"
         )
         logger.info(f"isMessageType.Weights?: {MessageType.WEIGHTS in msg}")
-
-        if MessageType.MODEL_VERSION in msg:
-            self._model_version = msg[MessageType.MODEL_VERSION]
 
         if MessageType.DATA_ID in msg and MessageType.ITERATION_PER_DATA_ID in msg:
             if (
@@ -270,7 +264,7 @@ class Trainer(Role, metaclass=ABCMeta):
             # dropped.
             logger.info("message type weights received")
             logger.info(
-                f"Trainer id: {self.trainer_id}|round: {self._round} |model version: {self._model_version} | weights: {list(msg[MessageType.WEIGHTS].keys())} |data id: {msg.get(MessageType.DATA_ID, 'N/A')} | iteration per data id: {msg.get(MessageType.ITERATION_PER_DATA_ID, 'N/A')}"
+                f"Trainer id: {self.trainer_id}|round: {self._round} |model version: {msg.get(MessageType.MODEL_VERSION, 'Model version is missing!!!')} | weights: {list(msg[MessageType.WEIGHTS].keys())} |data id: {msg.get(MessageType.DATA_ID, 'Data id is missing!!!')} | iteration per data id: {msg.get(MessageType.ITERATION_PER_DATA_ID, 'Iteration per data id is missing!!!')}"
             )
 
             # if self._round <= self._updates_returned_upto_round: logger.info(
@@ -303,6 +297,10 @@ class Trainer(Role, metaclass=ABCMeta):
             full_state_dict.update(trainable_weights)
             self.weights = full_state_dict
             self._update_model()
+
+            if MessageType.MODEL_VERSION in msg:
+                self._model_version = msg[MessageType.MODEL_VERSION]
+                logger.info(f"Trainer {self.trainer_id} actually updated local _model_version to {self._model_version} after receiving weights.")
 
             # Helper lambda for a cleaner log
             format_hash = lambda d: {k: _calculate_hash(v)[:8] for k, v in d.items()}


### PR DESCRIPTION
**Fix major bug in `_distribute_weights()` to send weights to a trainer that has not contributed to the current model version when `var = bad`.**

* **The Bug:** During a `var=bad` condition, newly selected mid-databin trainers were sent a weightless payload.
* **The Consequence:** The trainer would falsely update its local `_model_version`, blindly train its randomly-initialized fallback model, and return garbage gradients that were falsely calculated as having `0` staleness.
* **Aggregator Fix:** Added a `self._trainer_last_model_version` dict to explicitly track the exact model version each trainer has completed.
* **Aggregator Fix:** Dynamically overrides the payload inside the `_distribute_weights()` loop to send a full `WEIGHTS` payload to any stale trainers, regardless of the `var=bad` flag.
* **Trainer Fix:** Removed unconditional `_model_version` assignments. Locked version updates to trigger *only* if the `WEIGHTS` payload is legitimately parsed.

### Bug fix #2
* [Fix the problem of GRAD_POOL going as None for clients that had stale updates & needed weights & the updated GRAD_POOL to train]

Verified both using the log line: "skipped cosine_similarity checks because self.old_grad", which stops after a certain point when all trainers have received the message which contains weights & grad_pool