### PR TITLE
Smoke tests fix

### DIFF
--- a/lib/python/examples/async_cifar10/experiments/configs/refl_ablation_study.yaml
+++ b/lib/python/examples/async_cifar10/experiments/configs/refl_ablation_study.yaml
@@ -8,6 +8,7 @@ experiments:
     
     trainer:
       num_trainers: 100
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10
@@ -34,6 +35,7 @@ experiments:
     
     trainer:
       num_trainers: 100
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10
@@ -60,6 +62,7 @@ experiments:
     
     trainer:
       num_trainers: 100
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10
@@ -86,6 +89,7 @@ experiments:
     
     trainer:
       num_trainers: 100
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/experiments/configs/refl_monitoring_examples.yaml
+++ b/lib/python/examples/async_cifar10/experiments/configs/refl_monitoring_examples.yaml
@@ -82,6 +82,7 @@ experiments:
     
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/experiments/configs/refl_test_5trainers.yaml
+++ b/lib/python/examples/async_cifar10/experiments/configs/refl_test_5trainers.yaml
@@ -7,6 +7,7 @@ experiments:
     
     trainer:
       num_trainers: 5
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/experiments/configs/test_oort_syn0.yaml
+++ b/lib/python/examples/async_cifar10/experiments/configs/test_oort_syn0.yaml
@@ -7,6 +7,7 @@ experiments:
     
     trainer:
       num_trainers: 10  # Small test
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/experiments/configs/test_phase3_mini.yaml
+++ b/lib/python/examples/async_cifar10/experiments/configs/test_phase3_mini.yaml
@@ -3,6 +3,7 @@ experiments:
     
     trainer:
       num_trainers: 5
+      split_num_trainers: 300
       start_id: 1
       dataset:
         dirichlet_alpha: 0.1

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/fedavg_n10_alpha100_smoke.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/fedavg_n10_alpha100_smoke.yaml
@@ -12,6 +12,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/fedbuff_n10_alpha100_smoke.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/fedbuff_n10_alpha100_smoke.yaml
@@ -12,6 +12,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_alpha100_syn20_smoke.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_alpha100_syn20_smoke.yaml
@@ -13,6 +13,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_alpha100_syn20_telemetry_smoke.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_alpha100_syn20_telemetry_smoke.yaml
@@ -20,6 +20,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_parity_SIMULATED.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_parity_SIMULATED.yaml
@@ -4,6 +4,7 @@ experiments:
     baseline: felix
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_parity_real_vs_sim.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/felix_n10_parity_real_vs_sim.yaml
@@ -23,6 +23,7 @@ experiments:
     baseline: felix
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10
@@ -70,6 +71,7 @@ experiments:
     baseline: felix
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/felix_oort_refl_feddance_quickpilot_n32.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/felix_oort_refl_feddance_quickpilot_n32.yaml
@@ -26,6 +26,7 @@ experiments:
     baseline: felix
     trainer: &felix_tr
       num_trainers: 32
+      split_num_trainers: 300
       start_id: 1
       dataset: {name: cifar10, dirichlet_alpha: 0.1}
       availability: {mode: syn_0}
@@ -63,6 +64,7 @@ experiments:
     baseline: oort
     trainer:
       num_trainers: 32
+      split_num_trainers: 300
       start_id: 1
       dataset: {name: cifar10, dirichlet_alpha: 0.1}
       availability: {mode: syn_0}
@@ -103,6 +105,7 @@ experiments:
     baseline: refl
     trainer:
       num_trainers: 32
+      split_num_trainers: 300
       start_id: 1
       dataset: {name: cifar10, dirichlet_alpha: 0.1}
       availability: {mode: syn_0}
@@ -143,6 +146,7 @@ experiments:
     baseline: feddance
     trainer:
       num_trainers: 32
+      split_num_trainers: 300
       start_id: 1
       dataset: {name: cifar10, dirichlet_alpha: 0.1}
       availability: {mode: syn_0}

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/misselection_smoke_n10.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/misselection_smoke_n10.yaml
@@ -16,6 +16,7 @@ experiments:
     baseline: felix
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset: {name: cifar10, dirichlet_alpha: 0.1}
       availability: {mode: syn_0}
@@ -54,6 +55,7 @@ experiments:
     baseline: oort
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset: {name: cifar10, dirichlet_alpha: 0.1}
       availability: {mode: syn_0}

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/oort_n10_alpha100_syn0_smoke.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/oort_n10_alpha100_syn0_smoke.yaml
@@ -12,6 +12,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/oort_oracular_10trainer_demo.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/oort_oracular_10trainer_demo.yaml
@@ -20,6 +20,7 @@ experiments:
     
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10
@@ -45,6 +46,7 @@ experiments:
     
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/refl_10trainer_demo.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/refl_10trainer_demo.yaml
@@ -20,6 +20,7 @@ experiments:
     
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10
@@ -45,6 +46,7 @@ experiments:
     
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/async_cifar10/expt_scripts_2026/refl_n10_alpha100_syn0_smoke.yaml
+++ b/lib/python/examples/async_cifar10/expt_scripts_2026/refl_n10_alpha100_syn0_smoke.yaml
@@ -12,6 +12,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/cifar10/experiments/configs/smoke_10trainer.yaml
+++ b/lib/python/examples/cifar10/experiments/configs/smoke_10trainer.yaml
@@ -10,6 +10,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10

--- a/lib/python/examples/feddance_cifar10/experiments/configs/smoke_10trainer.yaml
+++ b/lib/python/examples/feddance_cifar10/experiments/configs/smoke_10trainer.yaml
@@ -10,6 +10,7 @@ experiments:
 
     trainer:
       num_trainers: 10
+      split_num_trainers: 300
       start_id: 1
       dataset:
         name: cifar10


### PR DESCRIPTION
Added split_num_trainers to test files that used a number of trainers not found in dataset_splits. This fixes the issue where these tests crash when ran due to not finding the correct split.