### PR TITLE
Scale FMoW to 200 Satellites

### DIFF
--- a/lib/python/examples/fmow/README-draft.md
+++ b/lib/python/examples/fmow/README-draft.md
@@ -1,0 +1,124 @@
+## FMoW on Flame — Federated Learning over Satellite Imagery
+
+This example ports **fMoW** (Functional Map of the World) onto Flame's federated
+learning stack, using a satellite-constellation framing: each trainer is a LEO
+satellite that only "sees" (and can train on) the subset of images it has
+physically captured so far in simulated time, rather than a static per-client
+data partition.
+
+### What is FMoW?
+
+fMoW is a satellite-image scene-classification dataset: RGB chips labeled with
+one of 62 land-use/scene categories (`airport`, `race_track`,
+`amusement_park`, ...), split into `train` / `val` / `test` / `seq`. This port
+uses the WILDS-preprocessed release (fMoW-rgb v1.1), which is a flat directory
+of already-resized 224x224 PNGs, `images/rgb_img_{i}.png`, where `i` is simply
+the row's position in `rgb_metadata.csv` — **not** the descriptive
+`train/<category>/<category>_<id>/...` path that the CSV's `img_path` column
+happens to contain (that column is vestigial in this distribution; see
+"Bugs found and fixed" below).
+
+### The satellite framing
+
+Instead of a Dirichlet or index-based split, data availability here is physical. `captures.py` uses the `geodetic.npz` LEO constellation to simulate every timestep and track when a satellite comes within a specified `radius` (km) of an image. Each trainer only trains on images captured up to the current simulated time, with its dataset growing over rounds rather than being fixed.
+
+Captures are given as `events`, where an event contains the `timestep` the event occurred on and the `image` captured. 
+
+### Layout
+
+```
+configs/
+  fmow_config.yaml     FMoW specific configuration
+  trainer_base.yaml    Flame trainer hyperparameters template
+                       (adds fmow_config_path, reuses satellite_coordinates_path)
+
+dependencies/
+  model.py             DenseNet161 (ImageNet-pretrained), group normalized and
+                       freeze_layers leaves only denseblock4/norm5/classifier trainable
+  fmow_dataset.py      Transforms dataset into Tensor arrays and allows for selection
+                       by split
+
+setup/
+  download_fmow_dataset.sh   downloads + extracts fMoW-rgb v1.1 (~54GB)
+  config.py                  FMoW configuration schema
+  captures.py                Builds captures.npz based on geodetic.npz (events + per-satellite offsets)
+  setup_fmow.py              One-time setup for FMoW: download, then schedule captures
+
+trainer/pytorch/main.py               PyTorchFMoWTrainer
+aggregator/pytorch/main_fedavg_agg.py PyTorchFMoWAggregator
+
+exports/fmow_fedavg_smoke_n10.yaml    FMoW smoketest:
+                                      baseline=fedavg, 10 trainers, 50 rounds
+exports/fmow_fedavg_n200.yaml         FMoW at scale:
+                                      baseline=fedavg, 200 trainers, 500 rounds,
+                                      capture-driven data (path_style: true)
+```
+
+`model.py`, `fmow_dataset.py`, and `config.py` are symlinked into both
+`trainer/pytorch/` and `aggregator/pytorch/` (mirroring the existing
+`metadata -> ../_metadata` convention), so both roles import the same code
+with a plain top-level `import model` / `from fmow_dataset import ...` rather
+than using `sys.path`, since Python auto-adds a directly-run script's own directory
+to `sys.path`. The one thing symlinks can't solve is locating the plain data
+file `fmow_config.yaml` itself, which is why `fmow_config_path` exists as a
+hyperparameter (set once in `trainer_base.yaml` for the trainer, and again
+under the experiment YAML's `aggregator.config_overrides.hyperparameters`,
+since the aggregator's config comes from a completely separate merge chain
+that never reads `trainer_base.yaml`).
+
+### How a round works
+
+**Trainer** (`PyTorchFMoWTrainer`, one per satellite): `initialize()` loads
+`fmow_config.yaml` and builds the model; `load_data()` loads this satellite's
+slice of `captures.npz`, admits whatever's been captured as of the current
+simulated time into `self.image_buffer`, and builds the train loader from it.
+Every `train()` call re-admits newly captured images and rebuilds the loader
+before training, so the dataset a satellite trains on grows as simulated time advances.
+
+**Aggregator** (`PyTorchFMoWAggregator`): standard FedAvg `TopAggregator` —
+`random` selector, `fedavg` optimizer, evaluates against the fMoW `test` split.
+
+### Scaling to 200 satellites
+
+The initial port validated at smoke-test scale (`fmow_fedavg_smoke_n10.yaml`:
+10 trainers, 50 rounds). Running `fmow_fedavg_n200.yaml` at real scale (200
+trainers, 500 rounds) surfaced failures smoke scale never exercised — mostly
+concurrency assumptions in shared framework code that no prior example on
+this framework had ever stressed, not bugs unique to FMoW. `async_cifar10`'s
+trainer is a small hand-written CNN over 32x32 images; FMoW's trainer runs a
+full DenseNet-161 (~28.7M params) over 224x224 images, with per-satellite
+datasets that grow into the thousands of images over a run. Nothing in the
+chunk transport or selector bookkeeping had ever needed to move or track this
+much per round before.
+
+### Bugs found and fixed
+
+**Framework-level** (`flame/selector/default.py`, affects every example using
+`selector.sort: default`, not just FMoW):
+- `DefaultSelector`'s initializer didn't accept `**kwargs`, so it broke the moment `channel_manager.py` started unconditionally injecting a `_seed` kwarg into every selector's constructor. Fixed to accept and forward `**kwargs` to `AbstractSelector`, matching every other selector class.
+- `DefaultSelector` was also missing `_cleanup_recvd_ends` and `_cleanup_send_ends` methods which seemed to be required by `channel.py` and `trainer.py`. Also missing `_cleanup_removed_ends(end_id)`, which discards a removed end from `selected_ends`.
+
+**FMoW-specific:**
+- `_rebuild_train_loader()` built its `DataLoader` with `shuffle=True`, and shuffling crashed whenever a satellite's capture buffer is still empty. Trainers having an empty dataset is specific to the way FMoW captures images over time. Fixed by gating `shuffle=len(indices) > 0`, and by skipping the epoch loop entirely in `train()` when there's nothing captured yet that round.
+
+**Framework-level, concurrency at real scale** (`flame/backend/chunk_manager.py`, `flame/backend/chunk_store.py`, affects any example moving large payloads under real concurrency, not just FMoW):
+- `ChunkStore.assemble()` required chunks to arrive in exact sequential order (`if self.seqno + 1 != msg.seqno: return False`), and any out-of-order chunk discarded the entire in-progress transfer, forcing a full resend. This only mattered once many trainers were sending large payloads concurrently over the same transport — at smoke scale, chunks arrived in order often enough that it never triggered. Fixed by keying `recv_buf` on `seqno` (a dict instead of a position-dependent list), so arrival order no longer matters; a transfer is only complete once every chunk from `0` to `eom_seqno` has actually arrived (`len(recv_buf) == eom_seqno + 1`). A duplicate chunk is now silently ignored instead of erroring. A new `is_stale()` check paired with a 30-second `TRANSFER_TIMEOUT` resets a transfer that started but never finished. `DEFAULT_CHUNK_SIZE` also went from 1MB to 4MB, cutting the number of chunks (and therefore the surface area for reordering) per transfer.
+- `RandomSelector` had no `on_round_completed()`, so `selected_ends` / `all_selected` were never cleared between rounds — once a trainer had been selected and responded, it stayed marked as such for the rest of the run. After the first round this made `agg_goal` unreachable and produced the same symptoms as `SIM_STARVATION`'s fast-forward mechanism, even though the aggregator wasn't actually out of eligible data, the selector's own bookkeeping had just never been cleared. Fixed by adding `RandomSelector.on_round_completed()`, called both when a round succeeds and when aggregation fails and returns no weights, so a failed round doesn't leave behind the same stale state a successful one used to. `channel._selector.on_update_received()` was also only being called from the branch handling real, weight-bearing responses, not the one for a trainer with nothing to contribute — moved so it fires regardless of which message branch a response came through. `SIM_STARVATION` logging was also extended with eligible count, threshold, total ends, and in-flight ends/IDs, since diagnosing this kind of state-tracking bug needs to see what the selector actually believed at the moment it gave up.
+
+**FMoW-specific, reducing what has to move per round:**
+- A trainer's `delta_weights` now drops every parameter whose `requires_grad` is `False` before sending. Since the model only trains its last dense block and classifier, the transmitted payload is a small fraction of the full DenseNet-161, meaning fewer chunks and less concurrent network pressure at any given moment.
+- An empty-dataset trainer previously still entered the full training/send path and produced a payload regardless of whether it had anything meaningful to contribute. It now sends a minimal status-only message (model version, dataset size (zero), stat utility, local accuracy) with no weights key at all.
+- A `random.uniform(0, 1)` second sleep was added on the simulated send path. Simulated trainers running the same modeled delay tend to finish and send in lockstep, producing synchronized bursts of concurrent traffic; the jitter spreads that out.
+
+**FMoW-specific, evaluation:**
+- The eval-skip condition (`if self._round != 1 and self._round % eval_every != 0: return`) could skip evaluation on the last round entirely if the round count didn't happen to land on the cadence. An explicit `is_last_round` check now forces evaluation on the final round regardless of cadence, and runs it synchronously rather than in a background thread, so the run doesn't exit before that last evaluation finishes.
+- Intermediate evaluations cap at 5 batches instead of the full test set, deliberately, since a full-test-set evaluation on every cadence hit at real scale would dominate per-round time on its own. The final round still evaluates the complete test set, uncapped. Progress is now logged per batch (`[EVAL_START]` / `[EVAL_PROGRESS]`).
+
+### Guards ahead of a dg-fork-main merge
+
+`dg-fork-main`'s latest commit (`4a75cb7a`, landing FwdLLM real/sim parity)
+doesn't touch FMoW's own code, but it changes two pieces of the shared
+framework FMoW depends on. Neither is fixed by a merge conflict, both are
+silent otherwise, so the guards are added here ahead of time:
+- `eval_every_n_commits: 1` added to `fmow_fedavg_n200.yaml`'s hyperparameters. `dg-fork-main` adds a separate per-commit stride gate inside `_eval_snapshot_model()` that stacks on top of `eval_every_n_rounds` rather than replacing it; left unset, it silently drops roughly half of every evaluation FMoW schedules (default stride is 2). Verified directly against the real run's cadence (500 rounds, `eval_every_n_rounds: 10`): 25 of 51 scheduled evaluations dropped with the gate unset, zero dropped with `eval_every_n_commits: 1`.
+- `main.py`'s heartbeat setup now reads `getattr(self.config.hyperparameters, "heartbeats", {})` instead of accessing `self.config.hyperparameters.heartbeats` directly. `dg-fork-main` removes the `heartbeats` field from the shared config schema entirely, with no default, so the direct access raises `AttributeError` on every trainer at startup, confirmed against the real run's actual config, which never sets `heartbeats` itself.

--- a/lib/python/examples/fmow/aggregator/pytorch/main_fedavg_agg.py
+++ b/lib/python/examples/fmow/aggregator/pytorch/main_fedavg_agg.py
@@ -86,7 +86,12 @@ class PyTorchFMoWAggregator(TopAggregator):
 
     def initialize(self):
         """Initialize role."""
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            self.device = torch.device("mps")
+        else:
+            self.device = torch.device("cpu")
         self.model = build_model(self.fmow_cfg.dataset.num_classes).to(self.device)
 
 
@@ -122,36 +127,51 @@ class PyTorchFMoWAggregator(TopAggregator):
         eval_every = (
             getattr(self.config.hyperparameters, "eval_every_n_rounds", 10) or 10
         )
-        if self._round != 1 and (self._round % eval_every != 0):
+        is_last_round = self._round >= self._rounds
+        if self._round != 1 and (self._round % eval_every != 0) and not is_last_round:
             return
         # Off the critical path: snapshot weights now, run the test-set forward
         # pass in a daemon thread so the aggregator keeps progressing.
         eval_model = self._eval_snapshot_model()
         if eval_model is None:
-            return  # prior async eval still running
+            return
         round_num = self._round
         test_loader, device = self.test_loader, self.device
+
+        max_batches = None if is_last_round else 5
 
         def _job():
             try:
                 eval_model.eval()
+                total_batches = len(test_loader) if max_batches is None else max_batches
+                logger.info(f"[EVAL_START] round={round_num} total_batches={total_batches} device={device}")
                 test_loss = 0
                 correct = 0
+                total = 0
                 with torch.no_grad():
-                    for data, target in test_loader:
+                    for i, (data, target) in enumerate(test_loader):
+                        if max_batches is not None and i >= max_batches:
+                            break
                         data, target = data.to(device), target.to(device)
                         output = eval_model(data)
                         test_loss += F.cross_entropy(output, target, reduction="sum").item()
                         pred = output.argmax(dim=1, keepdim=True)
                         correct += pred.eq(target.view_as(pred)).sum().item()
-                total = len(test_loader.dataset)
+                        total += data.size(0)
+                        if i % 100 == 0:
+                            logger.info(f"[EVAL_PROGRESS] round={round_num} batch={i}/{total_batches} samples={total}")
+                        
                 self._eval_emit(round_num, test_loss / total, correct / total)
+                self._eval_inflight = False
             except Exception as e:  # eval must never break training
                 logger.warning(f"[ASYNC_EVAL] failed (non-fatal): {e}")
                 self._eval_inflight = False
 
-        import threading
-        threading.Thread(target=_job, daemon=True).start()
+        if is_last_round:
+            _job()
+        else:
+            import threading
+            threading.Thread(target=_job, daemon=True).start()
 
         # print to save to file
         logger.debug(f"loss list at fmow agg: {self.loss_list}")

--- a/lib/python/examples/fmow/exports/fmow_fedavg_n200.yaml
+++ b/lib/python/examples/fmow/exports/fmow_fedavg_n200.yaml
@@ -38,6 +38,7 @@ experiments:
           rounds: 500
           fmow_config_path: "lib/python/examples/fmow/configs/fmow_config.yaml"
           eval_every_n_rounds: 10
+          eval_every_n_commits: 1
           checkpoint:
             enabled: 'True'
             every_n_rounds: 10

--- a/lib/python/examples/fmow/exports/fmow_fedavg_n200.yaml
+++ b/lib/python/examples/fmow/exports/fmow_fedavg_n200.yaml
@@ -1,0 +1,59 @@
+# FMoW FedAvg fullw test: 200 trainers, capture-driven data (no dirichlet
+# index split -- path_style: true).
+#
+# Run:
+#   python -m flame.launch.run_experiment \
+#       lib/python/examples/FMoW/expt_scripts_2026/fmow_fedavg_n200.yaml
+
+experiments:
+  - name: fmow_fedavg_n200
+    description: "FMoW FedAvg sync experiment (200 trainers, syn_0, capture-driven data)."
+
+    baseline: fedavg
+
+    trainer:
+      num_trainers: 200
+      start_id: 1
+      dataset:
+        path_style: true
+      availability:
+        mode: syn_0
+      enable_training_delays: true
+      hyperparameters:
+        batchSize: 16
+        learningRate: 0.0004
+
+    aggregator:
+      config_template: metadata/aggregator_base.json
+      selector: random
+      tracking_mode: default
+      agg_goal: 175
+      log_to_wandb: false
+      config_overrides:
+        job:
+          id: fmow_fedavg_smoke_n10
+        hyperparameters:
+          batchSize: 16
+          learningRate: 0.0004
+          rounds: 500
+          fmow_config_path: "lib/python/examples/fmow/configs/fmow_config.yaml"
+          eval_every_n_rounds: 10
+          checkpoint:
+            enabled: 'True'
+            every_n_rounds: 10
+          sim_unavailability: 'True'
+          availability_trace: syn_0
+          min_trainers_to_start: 200
+          min_trainers_join_timeout_s: 600
+          
+        selector:
+          kwargs:
+            k: 5
+            c: 200
+
+    execution:
+      num_gpus: 8
+      sleep_between_spawns: 0.3
+      aggregator_warmup_time: 15
+      monitoring:
+        enabled: false

--- a/lib/python/examples/fmow/trainer/pytorch/main.py
+++ b/lib/python/examples/fmow/trainer/pytorch/main.py
@@ -26,6 +26,7 @@ import sys
 import threading
 import time
 import math
+import random
 
 import numpy as np
 import torch
@@ -714,6 +715,8 @@ class PyTorchFMoWTrainer(Trainer):
 
         if not self.simulated and _remaining_time > 0:
             time.sleep(_remaining_time)
+        elif self.simulated:
+            time.sleep(random.uniform(0, 1))
 
         _cycle_elapsed = time.time() - _cycle_start
         if self.simulated:

--- a/lib/python/examples/fmow/trainer/pytorch/main.py
+++ b/lib/python/examples/fmow/trainer/pytorch/main.py
@@ -111,12 +111,14 @@ class PyTorchFMoWTrainer(Trainer):
         self.use_oort_loss_fn = self.config.hyperparameters.use_oort_loss_fn
         self.trainer_start_ts = time.time()
 
-        if "enabled" in self.config.hyperparameters.heartbeats:
+        heartbeats = getattr(self.config.hyperparameters, "heartbeats", {})
+        
+        if "enabled" in heartbeats:
             self.heartbeats_enabled = self.config.hyperparameters.heartbeats["enabled"]
         else:
             self.heartbeats_enabled = False
 
-        if "frequency_s" in self.config.hyperparameters.heartbeats:
+        if "frequency_s" in heartbeats:
             self.heartbeats_second_freq = self.config.hyperparameters.heartbeats[
                 "frequency_s"
             ]

--- a/lib/python/flame/backend/chunk_manager.py
+++ b/lib/python/flame/backend/chunk_manager.py
@@ -32,6 +32,7 @@ KEY_CHANNEL = "channel"
 KEY_END_ID = "end_id"
 
 QUEUE_TIMEOUT = 5  # 5 seconds
+TRANSFER_TIMEOUT = 30 # 30 seconds
 
 
 class ChunkThread(Thread):
@@ -100,49 +101,38 @@ class ChunkThread(Thread):
                 msg = self.queue.get(timeout=QUEUE_TIMEOUT)
             except Empty:
                 logger.debug("Currently empty")
+                if self.chunk_store.is_stale(TRANSFER_TIMEOUT):
+                    logger.warning(
+                        f"incomplete transfer for {self._end_id} stalled for "
+                        f"{TRANSFER_TIMEOUT}s (chunk likely lost); resetting"
+                    )
+                    self.chunk_store.reset()
+                    self._backend.set_cleanup_ready(self._end_id)
                 continue
 
             timestamp = datetime.now()
 
             # assemble is done in a chunk thread so that it won't block asyncio
             # task
-            if self.chunk_store.seqno + 1 != msg.seqno:
-                logger.info(
-                    f"about to assemble message for end id: {msg.end_id}. Might get out-of-order"
-                )
-            status = self.chunk_store.assemble(msg)
+            self.chunk_store.assemble(msg)
             logger.debug("Assemble attempted for chunkstore")
-            if not status:
-                # reset chunk_store if message is wrong
-                self.chunk_store.reset()
 
-                # set cleanup ready event for a given end id
+            if not self.chunk_store.eom:
+                logger.debug(f"self.chunk_store.eom is {self.chunk_store.eom}")
                 self._backend.set_cleanup_ready(msg.end_id)
-                logger.debug(
-                    f"EOM was set, put a cleanup ready for end_id: {msg.end_id}"
-                )
-            else:
-                logger.debug(f"Status is {status}")
-                if not self.chunk_store.eom:
-                    logger.debug(f"self.chunk_store.eom is {self.chunk_store.eom}")
-                    # not an end of message, hence, can't get a payload out of
-                    # chunk store yet
+                continue
+                
+            payload = self.chunk_store.get_data()
+            logger.debug(
+                f"Payload will now be pushed to target receive queue for end: {msg.end_id}"
+            )
+            # now push payload to a target receive queue.
+            _, status = run_async(
+                inner(msg.end_id, payload, timestamp), self._backend.loop()
+            )
 
-                    # set cleanup ready event for a given end id
-                    self._backend.set_cleanup_ready(msg.end_id)
-                    continue
-
-                payload = self.chunk_store.get_data()
-                logger.debug(
-                    f"Payload will now be pushed to target receive queue for end: {msg.end_id}"
-                )
-                # now push payload to a target receive queue.
-                _, status = run_async(
-                    inner(msg.end_id, payload, timestamp), self._backend.loop()
-                )
-
-                # message was completely assembled, reset the chunk store
-                self.chunk_store.reset()
+            # message was completely assembled, reset the chunk store
+            self.chunk_store.reset()
 
         logger.debug(f"finished chunk thread for {self._end_id}")
 

--- a/lib/python/flame/backend/chunk_store.py
+++ b/lib/python/flame/backend/chunk_store.py
@@ -16,12 +16,13 @@
 """ChunkStore."""
 
 import logging
+import time
 from typing import Tuple, Union
 
 from ..common.constants import EMPTY_PAYLOAD
 from ..proto import backend_msg_pb2 as msg_pb2
 
-DEFAULT_CHUNK_SIZE = 1048576  # 1MB
+DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024  # 4MB
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,9 @@ class ChunkStore(object):
         self.cidx = DEFAULT_CHUNK_SIZE
 
         # for assemble
-        self.recv_buf = list()
+        self.recv_buf = {}
+        self.eom_seqno = None
+        self._first_chunk_ts = None
 
         # for both fragment and assemble
         self.data = EMPTY_PAYLOAD
@@ -95,18 +98,31 @@ class ChunkStore(object):
         This method pushes message payload into a receive buffer. If eom (end of
         message) is set, bytes in the array are joined.
         """
-        # out of order delivery
-        if self.seqno + 1 != msg.seqno:
-            logger.warning(f"out-of-order seqno from {msg.end_id}")
-            return False
+
+        if msg.seqno in self.recv_buf:
+            logger.debug(f"duplicate seqno {msg.seqno} from {msg.end_id}, ignoring")
+            return True
+            
+        if self._first_chunk_ts is None:
+            self._first_chunk_ts = time.time()
 
         logger.debug(f"chunk {msg.seqno}: {len(msg.payload)}")
         # add payload to a recv buf
-        self.recv_buf.append(msg.payload)
-        self.seqno = msg.seqno
-        self.eom = msg.eom
+        self.recv_buf[msg.seqno] = msg.payload
 
-        if self.eom:
-            self.data = EMPTY_PAYLOAD.join(self.recv_buf)
+        if (msg.eom):
+            self.eom_seqno = msg.seqno
+            
+        if self.eom_seqno is not None and len(self.recv_buf) == self.eom_seqno + 1:
+            self.data = EMPTY_PAYLOAD.join(self.recv_buf[i] for i in range(self.eom_seqno + 1))
+            self.eom = True
 
         return True
+
+    def is_stale(self, timeout_s: float) -> bool:
+        return (
+            bool(self.recv_buf)
+            and not self.eom
+            and self._first_chunk_ts is not None
+            and (time.time() - self._first_chunk_ts) > timeout_s
+        )

--- a/lib/python/flame/mode/horizontal/syncfl/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/top_aggregator.py
@@ -852,6 +852,8 @@ class TopAggregator(ClientAvailability, Role, metaclass=ABCMeta):
         self._agg_cache_store_s = 0.0
         if global_weights is None:
             logger.debug("failed model aggregation")
+            if channel._selector is not None:
+                channel._selector.on_round_completed(channel._ends, self._round)
             time.sleep(1)
             return
 
@@ -1058,7 +1060,12 @@ class TopAggregator(ClientAvailability, Role, metaclass=ABCMeta):
                     logger.info(
                         f"[SIM_STARVATION] trace horizon or budget reached at "
                         f"vclock={self._vclock.now:.1f}s (nxt={_nxt}, "
-                        f"budget={_budget:.0f}s, round={self._round}); stopping run."
+                        f"budget={_budget:.0f}s, round={self._round}); stopping run. "
+                        f"num_eligible={num_eligible} threshold={_threshold} "
+                        f"total_ends={len(channel._ends)} "
+                        f"unavail={len(curr_unavail_trainer_list)} "
+                        f"in_flight={len(_in_flight)} "
+                        f"in_flight_ids={sorted(_in_flight)}"
                     )
             else:
                 _max_rt = getattr(self.config.hyperparameters, "max_experiment_runtime_s", None)

--- a/lib/python/flame/mode/horizontal/syncfl/top_aggregator.py
+++ b/lib/python/flame/mode/horizontal/syncfl/top_aggregator.py
@@ -764,8 +764,6 @@ class TopAggregator(ClientAvailability, Role, metaclass=ABCMeta):
                 self._agg_cache_store_s = (
                     getattr(self, "_agg_cache_store_s", 0.0) + time.time() - _cs0)
 
-                if channel._selector is not None:
-                    channel._selector.on_update_received(end, msg, self._round)
 
                 update_staleness_val = self._round - tres.version
 
@@ -792,6 +790,9 @@ class TopAggregator(ClientAvailability, Role, metaclass=ABCMeta):
                     _rd.total_seconds() if _rd is not None else 0.0
                 )
 
+            if channel._selector is not None:
+                channel._selector.on_update_received(end, msg, self._round)
+                
         logger.debug(f"received {len(self.cache)} trainer updates in cache")
 
         # [U6 real barrier-anchor] Finalize real visibility lag against the single round barrier:

--- a/lib/python/flame/mode/horizontal/syncfl/trainer.py
+++ b/lib/python/flame/mode/horizontal/syncfl/trainer.py
@@ -414,7 +414,7 @@ class Trainer(Role, metaclass=ABCMeta):
         # one aggregator is sufficient
         end = channel.one_end(VAL_CH_STATE_SEND)
 
-        if self.task_to_perform == "train":
+        if self.task_to_perform == "train" and self.dataset_size > 0:
             # trainer is expected to train and it is also available to
             # train - best case
             with self._phase("weights_from_gpu_s"):
@@ -428,6 +428,17 @@ class Trainer(Role, metaclass=ABCMeta):
 
                 delta_weights = self.privacy.apply_dp_fn(delta_weights)
 
+                # Skip frozen layers
+                if hasattr(self.model, "named_parameters"):
+                    _frozen = {
+                        n for n, p in self.model.named_parameters() if not p.requires_grad
+                    }
+
+                    if _frozen:
+                        delta_weights = {
+                            k: v for k, v in delta_weights.items() if k not in _frozen
+                        }
+
                 self.regularizer.update()
 
                 self.finalize_local_accuracy()
@@ -440,6 +451,13 @@ class Trainer(Role, metaclass=ABCMeta):
                     MessageType.STAT_UTILITY: self._stat_utility,
                     MessageType.LOCAL_ACCURACY: self._local_accuracy,
                 }
+        elif self.task_to_perform == "train":
+            msg = {
+                MessageType.MODEL_VERSION: self._round,
+                MessageType.DATASET_SIZE: self.dataset_size,
+                MessageType.STAT_UTILITY: self._stat_utility,
+                MessageType.LOCAL_ACCURACY: self._local_accuracy
+            }
         else:
             msg = {
                 MessageType.MODEL_VERSION: self._round,

--- a/lib/python/flame/selector/default.py
+++ b/lib/python/flame/selector/default.py
@@ -38,6 +38,9 @@ class DefaultSelector(AbstractSelector):
     def _cleanup_send_ends(self) -> None:
         pass
 
+    def _cleanup_removed_ends(self, end_id) -> None:
+        self.selected_ends.discard(end_id)
+
     def select(
         self, ends: dict[str, End], channel_props: dict[str, Scalar], **kwargs
     ) -> SelectorReturnType:

--- a/lib/python/flame/selector/random.py
+++ b/lib/python/flame/selector/random.py
@@ -650,3 +650,9 @@ class RandomSelector(AbstractSelector):
         #         logger.debug( f"Attempted to remove end {end_id} from "
         #             f"self.selected_ends {self.selected_ends}, but it wasnt in
         #             ends")
+        
+    def on_round_completed(self, ends: dict[str, End], round_num: int) -> None:
+        for end_id in self.ordered_updates_recv_ends:
+            self.selected_ends.discard(end_id)
+            self.all_selected.pop(end_id, None)
+        self.ordered_updates_recv_ends = []


### PR DESCRIPTION
**Scaling to 200 satellites**
- Fixed chunk transport to tolerate out-of-order delivery under concurrency, added a 30s stale-transfer timeout, doubled chunk size to 4MB
- Fixed RandomSelector never resetting selected_ends/all_selected between rounds which made agg_goal unreachable and triggered false SIM_STARVATION after the first round
- Reduced per-round payload size: frozen-layer parameters excluded from delta_weights, empty-dataset trainers now send a status-only message instead of a full payload, added send jitter to avoid synchronized traffic bursts

**Evaluation**
- Final round now always evaluates (previously skippable), runs synchronously so the run doesn't exit before it finishes

**Guards ahead of a dg-fork-main merge**
- eval_every_n_commits set 1 to neutralize a new change that would otherwise silently drop ~half of scheduled evaluations
- heartbeats config access now uses getattr with a default, since the field is being removed from the shared schema upstream